### PR TITLE
ESRG as a Sass Mixin

### DIFF
--- a/css/example-grid.css
+++ b/css/example-grid.css
@@ -1,0 +1,423 @@
+/* 
+  Extra Strength Responsive Grids
+  Author & copyright (c) 2013: John Polacek 
+  Follow me on Twitter: @johnpolacek
+
+  Dual MIT & GPL license
+
+  Project Page: http://dfcb.github.com/extra-strength-responsive-grids
+  Project Repo: https://github.com/dfcb/extra-strength-responsive-grids
+  
+  Note: box-sizing: border-box; is required for this solution. 
+  For more info, see the project page
+
+  See examples-grid.scss for usage.
+*/
+.grid-all, .grid-1, .grid-2, .grid-3, .grid-quarter, .grid-4, .grid-third, .grid-5, .grid-6, .grid-half, .grid-7, .grid-8, .grid-two-thirds, .grid-9, .grid-three-quarters, .grid-10, .grid-11, .grid-12, .grid-whole {
+  margin: 0;
+  clear: none;
+  float: left;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  *behavior: url(boxsizing.htc); }
+
+.grid-1 {
+  width: 8.33333%; }
+
+.grid-2 {
+  width: 16.66667%; }
+
+.grid-3, .grid-quarter {
+  width: 25%; }
+
+.grid-4, .grid-third {
+  width: 33.33333%; }
+
+.grid-5 {
+  width: 41.66667%; }
+
+.grid-6, .grid-half {
+  width: 50%; }
+
+.grid-7 {
+  width: 58.33333%; }
+
+.grid-8, .grid-two-thirds {
+  width: 66.66667%; }
+
+.grid-9, .grid-three-quarters {
+  width: 75%; }
+
+.grid-10 {
+  width: 83.33333%; }
+
+.grid-11 {
+  width: 91.66667%; }
+
+.grid-12, .grid-whole {
+  width: 100%; }
+
+/* padding helper classes */
+.padded {
+  padding: 0.5em; }
+
+.padded-left {
+  padding-left: 0.5em; }
+
+.padded-right {
+  padding-right: 0.5em; }
+
+.padded-top {
+  padding-top: 0.5em; }
+
+.padded-bottom {
+  padding-bottom: 0.5em; }
+
+.padded-sides {
+  padding: 0 0.5em; }
+
+.padded-vertical {
+  padding: 0.5em 0; }
+
+.padded-inner {
+  padding: 1em; }
+
+.padded-inner-sides {
+  padding: 0 1em; }
+
+.padded-reverse {
+  margin: 0 -0.5em;
+  width: auto;
+  box-sizing: content-box;
+  float: none; }
+
+.padded-reverse-all {
+  margin: -0.5em;
+  width: auto;
+  box-sizing: content-box;
+  float: none; }
+
+/* miscellaneous helper classes */
+.flow-opposite {
+  float: right; }
+
+.center {
+  text-align: center; }
+
+.left {
+  text-align: left; }
+
+.right {
+  text-align: right; }
+
+/* For compatibility with Bootstrap (fixed), Foundation, etc. */
+.row {
+  margin: 0 -0.5em;
+  width: auto;
+  box-sizing: content-box;
+  float: none; }
+
+@media (max-width: 480px) {
+  .s-grid-all, .s-grid-1, .s-grid-2, .s-grid-3, .s-grid-quarter, .s-grid-4, .s-grid-third, .s-grid-5, .s-grid-6, .s-grid-half, .s-grid-7, .s-grid-8, .s-grid-two-thirds, .s-grid-9, .s-grid-three-quarters, .s-grid-10, .s-grid-11, .s-grid-12, .s-grid-whole {
+    margin: 0;
+    clear: none;
+    float: left;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    *behavior: url(boxsizing.htc); }
+
+  .s-grid-1 {
+    width: 8.33333%; }
+
+  .s-grid-2 {
+    width: 16.66667%; }
+
+  .s-grid-3, .s-grid-quarter {
+    width: 25%; }
+
+  .s-grid-4, .s-grid-third {
+    width: 33.33333%; }
+
+  .s-grid-5 {
+    width: 41.66667%; }
+
+  .s-grid-6, .s-grid-half {
+    width: 50%; }
+
+  .s-grid-7 {
+    width: 58.33333%; }
+
+  .s-grid-8, .s-grid-two-thirds {
+    width: 66.66667%; }
+
+  .s-grid-9, .s-grid-three-quarters {
+    width: 75%; }
+
+  .s-grid-10 {
+    width: 83.33333%; }
+
+  .s-grid-11 {
+    width: 91.66667%; }
+
+  .s-grid-12, .s-grid-whole {
+    width: 100%; }
+
+  /* padding helper classes */
+  .s-padded {
+    padding: 0.5em; }
+
+  .s-padded-left {
+    padding-left: 0.5em; }
+
+  .s-padded-right {
+    padding-right: 0.5em; }
+
+  .s-padded-top {
+    padding-top: 0.5em; }
+
+  .s-padded-bottom {
+    padding-bottom: 0.5em; }
+
+  .s-padded-sides {
+    padding: 0 0.5em; }
+
+  .s-padded-vertical {
+    padding: 0.5em 0; }
+
+  .s-padded-inner {
+    padding: 1em; }
+
+  .s-padded-inner-sides {
+    padding: 0 1em; }
+
+  .s-padded-reverse {
+    margin: 0 -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  .s-padded-reverse-all {
+    margin: -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  /* miscellaneous helper classes */
+  .s-flow-opposite {
+    float: right; }
+
+  .s-center {
+    text-align: center; }
+
+  .s-left {
+    text-align: left; }
+
+  .s-right {
+    text-align: right; }
+
+  .s-hidden {
+    display: none; } }
+@media (min-width: 481px) and (max-width: 800px) {
+  .m-grid-all, .m-grid-1, .m-grid-2, .m-grid-3, .m-grid-quarter, .m-grid-4, .m-grid-third, .m-grid-5, .m-grid-6, .m-grid-half, .m-grid-7, .m-grid-8, .m-grid-two-thirds, .m-grid-9, .m-grid-three-quarters, .m-grid-10, .m-grid-11, .m-grid-12, .m-grid-whole {
+    margin: 0;
+    clear: none;
+    float: left;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    *behavior: url(boxsizing.htc); }
+
+  .m-grid-1 {
+    width: 8.33333%; }
+
+  .m-grid-2 {
+    width: 16.66667%; }
+
+  .m-grid-3, .m-grid-quarter {
+    width: 25%; }
+
+  .m-grid-4, .m-grid-third {
+    width: 33.33333%; }
+
+  .m-grid-5 {
+    width: 41.66667%; }
+
+  .m-grid-6, .m-grid-half {
+    width: 50%; }
+
+  .m-grid-7 {
+    width: 58.33333%; }
+
+  .m-grid-8, .m-grid-two-thirds {
+    width: 66.66667%; }
+
+  .m-grid-9, .m-grid-three-quarters {
+    width: 75%; }
+
+  .m-grid-10 {
+    width: 83.33333%; }
+
+  .m-grid-11 {
+    width: 91.66667%; }
+
+  .m-grid-12, .m-grid-whole {
+    width: 100%; }
+
+  /* padding helper classes */
+  .m-padded {
+    padding: 0.5em; }
+
+  .m-padded-left {
+    padding-left: 0.5em; }
+
+  .m-padded-right {
+    padding-right: 0.5em; }
+
+  .m-padded-top {
+    padding-top: 0.5em; }
+
+  .m-padded-bottom {
+    padding-bottom: 0.5em; }
+
+  .m-padded-sides {
+    padding: 0 0.5em; }
+
+  .m-padded-vertical {
+    padding: 0.5em 0; }
+
+  .m-padded-inner {
+    padding: 1em; }
+
+  .m-padded-inner-sides {
+    padding: 0 1em; }
+
+  .m-padded-reverse {
+    margin: 0 -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  .m-padded-reverse-all {
+    margin: -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  /* miscellaneous helper classes */
+  .m-flow-opposite {
+    float: right; }
+
+  .m-center {
+    text-align: center; }
+
+  .m-left {
+    text-align: left; }
+
+  .m-right {
+    text-align: right; }
+
+  .m-hidden {
+    display: none; } }
+@media (min-width: 801px) {
+  .l-grid-all, .l-grid-1, .l-grid-2, .l-grid-3, .l-grid-quarter, .l-grid-4, .l-grid-third, .l-grid-5, .l-grid-6, .l-grid-half, .l-grid-7, .l-grid-8, .l-grid-two-thirds, .l-grid-9, .l-grid-three-quarters, .l-grid-10, .l-grid-11, .l-grid-12, .l-grid-whole {
+    margin: 0;
+    clear: none;
+    float: left;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    *behavior: url(boxsizing.htc); }
+
+  .l-grid-1 {
+    width: 8.33333%; }
+
+  .l-grid-2 {
+    width: 16.66667%; }
+
+  .l-grid-3, .l-grid-quarter {
+    width: 25%; }
+
+  .l-grid-4, .l-grid-third {
+    width: 33.33333%; }
+
+  .l-grid-5 {
+    width: 41.66667%; }
+
+  .l-grid-6, .l-grid-half {
+    width: 50%; }
+
+  .l-grid-7 {
+    width: 58.33333%; }
+
+  .l-grid-8, .l-grid-two-thirds {
+    width: 66.66667%; }
+
+  .l-grid-9, .l-grid-three-quarters {
+    width: 75%; }
+
+  .l-grid-10 {
+    width: 83.33333%; }
+
+  .l-grid-11 {
+    width: 91.66667%; }
+
+  .l-grid-12, .l-grid-whole {
+    width: 100%; }
+
+  /* padding helper classes */
+  .l-padded {
+    padding: 0.5em; }
+
+  .l-padded-left {
+    padding-left: 0.5em; }
+
+  .l-padded-right {
+    padding-right: 0.5em; }
+
+  .l-padded-top {
+    padding-top: 0.5em; }
+
+  .l-padded-bottom {
+    padding-bottom: 0.5em; }
+
+  .l-padded-sides {
+    padding: 0 0.5em; }
+
+  .l-padded-vertical {
+    padding: 0.5em 0; }
+
+  .l-padded-inner {
+    padding: 1em; }
+
+  .l-padded-inner-sides {
+    padding: 0 1em; }
+
+  .l-padded-reverse {
+    margin: 0 -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  .l-padded-reverse-all {
+    margin: -0.5em;
+    width: auto;
+    box-sizing: content-box;
+    float: none; }
+
+  /* miscellaneous helper classes */
+  .l-flow-opposite {
+    float: right; }
+
+  .l-center {
+    text-align: center; }
+
+  .l-left {
+    text-align: left; }
+
+  .l-right {
+    text-align: right; }
+
+  .l-hidden {
+    display: none; } }

--- a/css/example-grid.scss
+++ b/css/example-grid.scss
@@ -1,0 +1,42 @@
+//  Extra Strength Responsive Grids
+//  Author & copyright (c) 2013: John Polacek 
+//  Follow me on Twitter: @johnpolacek
+
+//  Dual MIT & GPL license
+
+//  Project Page: http://dfcb.github.com/extra-strength-responsive-grids
+//  Project Repo: https://github.com/dfcb/extra-strength-responsive-grids
+  
+//  Note: box-sizing: border-box; is required for this solution. 
+//  For more info, see the project page
+
+
+@import 'grid.scss';
+
+// Default settings
+//   (0, 480px, 800px), // breakpoints
+//   'px',              // breakpoint type px or em 
+//   12,                // number of grid columns 
+//   .5em,              // outer padding 
+//   1em,               // inner padding 
+//   (s-,m-,l-)         // breakpoint prefixes
+
+
+// Call the grid generator using the defaults
+@include gridGenerator();
+
+// Optionally call grid generator with em units
+// @include gridGenerator(
+//   (0, 35em, 55em),   // breakpoints
+//   'em',              // breakpoint type 'px' or 'em'
+// );
+
+// Optionally call grid generator, overwritting all the defaults
+// @include gridGenerator(
+//   (0, 35em, 55em),   // breakpoints
+//   'em',              // breakpoint type 'px' or 'em'
+//   18,                // number of grid columns
+//   1em,               // outer padding
+//   1.5em,             // inner padding
+//   (sm-,med-,lg-)     // breakpoint prefixes
+// );

--- a/css/grid.css
+++ b/css/grid.css
@@ -11,6 +11,7 @@
   Note: box-sizing: border-box; is required for this solution. 
   For more info, see the project page
 
+  See examples-grid.scss for usage.
 */
 .grid-all, .grid-1, .grid-2, .grid-3, .grid-quarter, .grid-4, .grid-third, .grid-5, .grid-6, .grid-half, .grid-7, .grid-8, .grid-two-thirds, .grid-9, .grid-three-quarters, .grid-10, .grid-11, .grid-12, .grid-whole {
   margin: 0;
@@ -19,132 +20,103 @@
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  *behavior: url(boxsizing.htc);
-}
+  *behavior: url(boxsizing.htc); }
 
 .grid-1 {
-  width: 8.33333%;
-}
+  width: 8.33333%; }
 
 .grid-2 {
-  width: 16.66667%;
-}
+  width: 16.66667%; }
 
 .grid-3, .grid-quarter {
-  width: 25%;
-}
+  width: 25%; }
 
 .grid-4, .grid-third {
-  width: 33.33333%;
-}
+  width: 33.33333%; }
 
 .grid-5 {
-  width: 41.66667%;
-}
+  width: 41.66667%; }
 
 .grid-6, .grid-half {
-  width: 50%;
-}
+  width: 50%; }
 
 .grid-7 {
-  width: 58.33333%;
-}
+  width: 58.33333%; }
 
 .grid-8, .grid-two-thirds {
-  width: 66.66667%;
-}
+  width: 66.66667%; }
 
 .grid-9, .grid-three-quarters {
-  width: 75%;
-}
+  width: 75%; }
 
 .grid-10 {
-  width: 83.33333%;
-}
+  width: 83.33333%; }
 
 .grid-11 {
-  width: 91.66667%;
-}
+  width: 91.66667%; }
 
 .grid-12, .grid-whole {
-  width: 100%;
-}
+  width: 100%; }
 
 /* padding helper classes */
 .padded {
-  padding: 0.5em;
-}
+  padding: 0.5em; }
 
 .padded-left {
-  padding-left: 0.5em;
-}
+  padding-left: 0.5em; }
 
 .padded-right {
-  padding-right: 0.5em;
-}
+  padding-right: 0.5em; }
 
 .padded-top {
-  padding-top: 0.5em;
-}
+  padding-top: 0.5em; }
 
 .padded-bottom {
-  padding-bottom: 0.5em;
-}
+  padding-bottom: 0.5em; }
 
 .padded-sides {
-  padding: 0 0.5em;
-}
+  padding: 0 0.5em; }
 
 .padded-vertical {
-  padding: 0.5em 0;
-}
+  padding: 0.5em 0; }
 
 .padded-inner {
-  padding: 1em;
-}
+  padding: 1em; }
 
 .padded-inner-sides {
-  padding: 0 1em;
-}
+  padding: 0 1em; }
 
 .padded-reverse {
   margin: 0 -0.5em;
   width: auto;
   box-sizing: content-box;
-  float: none;
-}
+  float: none; }
 
 .padded-reverse-all {
   margin: -0.5em;
   width: auto;
   box-sizing: content-box;
-  float: none;
-}
+  float: none; }
 
 /* miscellaneous helper classes */
 .flow-opposite {
-  float: right;
-}
+  float: right; }
 
 .center {
-  text-align: center;
-}
+  text-align: center; }
 
 .left {
-  text-align: left;
-}
+  text-align: left; }
 
 .right {
-  text-align: right;
-}
+  text-align: right; }
 
 /* For compatibility with Bootstrap (fixed), Foundation, etc. */
 .row {
   margin: 0 -0.5em;
   width: auto;
   box-sizing: content-box;
-  float: none;
-}
+  float: none; }
 
 @media (max-width: 480px) {
   .s-grid-all, .s-grid-1, .s-grid-2, .s-grid-3, .s-grid-quarter, .s-grid-4, .s-grid-third, .s-grid-5, .s-grid-6, .s-grid-half, .s-grid-7, .s-grid-8, .s-grid-two-thirds, .s-grid-9, .s-grid-three-quarters, .s-grid-10, .s-grid-11, .s-grid-12, .s-grid-whole {
@@ -154,129 +126,99 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    *behavior: url(boxsizing.htc);
-  }
+    *behavior: url(boxsizing.htc); }
 
   .s-grid-1 {
-    width: 8.33333%;
-  }
+    width: 8.33333%; }
 
   .s-grid-2 {
-    width: 16.66667%;
-  }
+    width: 16.66667%; }
 
   .s-grid-3, .s-grid-quarter {
-    width: 25%;
-  }
+    width: 25%; }
 
   .s-grid-4, .s-grid-third {
-    width: 33.33333%;
-  }
+    width: 33.33333%; }
 
   .s-grid-5 {
-    width: 41.66667%;
-  }
+    width: 41.66667%; }
 
   .s-grid-6, .s-grid-half {
-    width: 50%;
-  }
+    width: 50%; }
 
   .s-grid-7 {
-    width: 58.33333%;
-  }
+    width: 58.33333%; }
 
   .s-grid-8, .s-grid-two-thirds {
-    width: 66.66667%;
-  }
+    width: 66.66667%; }
 
   .s-grid-9, .s-grid-three-quarters {
-    width: 75%;
-  }
+    width: 75%; }
 
   .s-grid-10 {
-    width: 83.33333%;
-  }
+    width: 83.33333%; }
 
   .s-grid-11 {
-    width: 91.66667%;
-  }
+    width: 91.66667%; }
 
   .s-grid-12, .s-grid-whole {
-    width: 100%;
-  }
+    width: 100%; }
 
   /* padding helper classes */
   .s-padded {
-    padding: 0.5em;
-  }
+    padding: 0.5em; }
 
   .s-padded-left {
-    padding-left: 0.5em;
-  }
+    padding-left: 0.5em; }
 
   .s-padded-right {
-    padding-right: 0.5em;
-  }
+    padding-right: 0.5em; }
 
   .s-padded-top {
-    padding-top: 0.5em;
-  }
+    padding-top: 0.5em; }
 
   .s-padded-bottom {
-    padding-bottom: 0.5em;
-  }
+    padding-bottom: 0.5em; }
 
   .s-padded-sides {
-    padding: 0 0.5em;
-  }
+    padding: 0 0.5em; }
 
   .s-padded-vertical {
-    padding: 0.5em 0;
-  }
+    padding: 0.5em 0; }
 
   .s-padded-inner {
-    padding: 1em;
-  }
+    padding: 1em; }
 
   .s-padded-inner-sides {
-    padding: 0 1em;
-  }
+    padding: 0 1em; }
 
   .s-padded-reverse {
     margin: 0 -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   .s-padded-reverse-all {
     margin: -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   /* miscellaneous helper classes */
   .s-flow-opposite {
-    float: right;
-  }
+    float: right; }
 
   .s-center {
-    text-align: center;
-  }
+    text-align: center; }
 
   .s-left {
-    text-align: left;
-  }
+    text-align: left; }
 
   .s-right {
-    text-align: right;
-  }
+    text-align: right; }
 
   .s-hidden {
-    display: none;
-  }
-}
+    display: none; } }
 @media (min-width: 481px) and (max-width: 800px) {
   .m-grid-all, .m-grid-1, .m-grid-2, .m-grid-3, .m-grid-quarter, .m-grid-4, .m-grid-third, .m-grid-5, .m-grid-6, .m-grid-half, .m-grid-7, .m-grid-8, .m-grid-two-thirds, .m-grid-9, .m-grid-three-quarters, .m-grid-10, .m-grid-11, .m-grid-12, .m-grid-whole {
     margin: 0;
@@ -285,129 +227,99 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    *behavior: url(boxsizing.htc);
-  }
+    *behavior: url(boxsizing.htc); }
 
   .m-grid-1 {
-    width: 8.33333%;
-  }
+    width: 8.33333%; }
 
   .m-grid-2 {
-    width: 16.66667%;
-  }
+    width: 16.66667%; }
 
   .m-grid-3, .m-grid-quarter {
-    width: 25%;
-  }
+    width: 25%; }
 
   .m-grid-4, .m-grid-third {
-    width: 33.33333%;
-  }
+    width: 33.33333%; }
 
   .m-grid-5 {
-    width: 41.66667%;
-  }
+    width: 41.66667%; }
 
   .m-grid-6, .m-grid-half {
-    width: 50%;
-  }
+    width: 50%; }
 
   .m-grid-7 {
-    width: 58.33333%;
-  }
+    width: 58.33333%; }
 
   .m-grid-8, .m-grid-two-thirds {
-    width: 66.66667%;
-  }
+    width: 66.66667%; }
 
   .m-grid-9, .m-grid-three-quarters {
-    width: 75%;
-  }
+    width: 75%; }
 
   .m-grid-10 {
-    width: 83.33333%;
-  }
+    width: 83.33333%; }
 
   .m-grid-11 {
-    width: 91.66667%;
-  }
+    width: 91.66667%; }
 
   .m-grid-12, .m-grid-whole {
-    width: 100%;
-  }
+    width: 100%; }
 
   /* padding helper classes */
   .m-padded {
-    padding: 0.5em;
-  }
+    padding: 0.5em; }
 
   .m-padded-left {
-    padding-left: 0.5em;
-  }
+    padding-left: 0.5em; }
 
   .m-padded-right {
-    padding-right: 0.5em;
-  }
+    padding-right: 0.5em; }
 
   .m-padded-top {
-    padding-top: 0.5em;
-  }
+    padding-top: 0.5em; }
 
   .m-padded-bottom {
-    padding-bottom: 0.5em;
-  }
+    padding-bottom: 0.5em; }
 
   .m-padded-sides {
-    padding: 0 0.5em;
-  }
+    padding: 0 0.5em; }
 
   .m-padded-vertical {
-    padding: 0.5em 0;
-  }
+    padding: 0.5em 0; }
 
   .m-padded-inner {
-    padding: 1em;
-  }
+    padding: 1em; }
 
   .m-padded-inner-sides {
-    padding: 0 1em;
-  }
+    padding: 0 1em; }
 
   .m-padded-reverse {
     margin: 0 -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   .m-padded-reverse-all {
     margin: -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   /* miscellaneous helper classes */
   .m-flow-opposite {
-    float: right;
-  }
+    float: right; }
 
   .m-center {
-    text-align: center;
-  }
+    text-align: center; }
 
   .m-left {
-    text-align: left;
-  }
+    text-align: left; }
 
   .m-right {
-    text-align: right;
-  }
+    text-align: right; }
 
   .m-hidden {
-    display: none;
-  }
-}
+    display: none; } }
 @media (min-width: 801px) {
   .l-grid-all, .l-grid-1, .l-grid-2, .l-grid-3, .l-grid-quarter, .l-grid-4, .l-grid-third, .l-grid-5, .l-grid-6, .l-grid-half, .l-grid-7, .l-grid-8, .l-grid-two-thirds, .l-grid-9, .l-grid-three-quarters, .l-grid-10, .l-grid-11, .l-grid-12, .l-grid-whole {
     margin: 0;
@@ -416,126 +328,96 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    *behavior: url(boxsizing.htc);
-  }
+    *behavior: url(boxsizing.htc); }
 
   .l-grid-1 {
-    width: 8.33333%;
-  }
+    width: 8.33333%; }
 
   .l-grid-2 {
-    width: 16.66667%;
-  }
+    width: 16.66667%; }
 
   .l-grid-3, .l-grid-quarter {
-    width: 25%;
-  }
+    width: 25%; }
 
   .l-grid-4, .l-grid-third {
-    width: 33.33333%;
-  }
+    width: 33.33333%; }
 
   .l-grid-5 {
-    width: 41.66667%;
-  }
+    width: 41.66667%; }
 
   .l-grid-6, .l-grid-half {
-    width: 50%;
-  }
+    width: 50%; }
 
   .l-grid-7 {
-    width: 58.33333%;
-  }
+    width: 58.33333%; }
 
   .l-grid-8, .l-grid-two-thirds {
-    width: 66.66667%;
-  }
+    width: 66.66667%; }
 
   .l-grid-9, .l-grid-three-quarters {
-    width: 75%;
-  }
+    width: 75%; }
 
   .l-grid-10 {
-    width: 83.33333%;
-  }
+    width: 83.33333%; }
 
   .l-grid-11 {
-    width: 91.66667%;
-  }
+    width: 91.66667%; }
 
   .l-grid-12, .l-grid-whole {
-    width: 100%;
-  }
+    width: 100%; }
 
   /* padding helper classes */
   .l-padded {
-    padding: 0.5em;
-  }
+    padding: 0.5em; }
 
   .l-padded-left {
-    padding-left: 0.5em;
-  }
+    padding-left: 0.5em; }
 
   .l-padded-right {
-    padding-right: 0.5em;
-  }
+    padding-right: 0.5em; }
 
   .l-padded-top {
-    padding-top: 0.5em;
-  }
+    padding-top: 0.5em; }
 
   .l-padded-bottom {
-    padding-bottom: 0.5em;
-  }
+    padding-bottom: 0.5em; }
 
   .l-padded-sides {
-    padding: 0 0.5em;
-  }
+    padding: 0 0.5em; }
 
   .l-padded-vertical {
-    padding: 0.5em 0;
-  }
+    padding: 0.5em 0; }
 
   .l-padded-inner {
-    padding: 1em;
-  }
+    padding: 1em; }
 
   .l-padded-inner-sides {
-    padding: 0 1em;
-  }
+    padding: 0 1em; }
 
   .l-padded-reverse {
     margin: 0 -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   .l-padded-reverse-all {
     margin: -0.5em;
     width: auto;
     box-sizing: content-box;
-    float: none;
-  }
+    float: none; }
 
   /* miscellaneous helper classes */
   .l-flow-opposite {
-    float: right;
-  }
+    float: right; }
 
   .l-center {
-    text-align: center;
-  }
+    text-align: center; }
 
   .l-left {
-    text-align: left;
-  }
+    text-align: left; }
 
   .l-right {
-    text-align: right;
-  }
+    text-align: right; }
 
   .l-hidden {
-    display: none;
-  }
-}
+    display: none; } }

--- a/css/grid.scss
+++ b/css/grid.scss
@@ -11,57 +11,55 @@
   Note: box-sizing: border-box; is required for this solution. 
   For more info, see the project page
 
+  See examples-grid.scss for usage.
 */
 
-$grid_columns: 12;
-$padOuter: .5em;
-$padInner: 1em;
-$breakpoints: 0, 480px, 800px;
-$breakpoint_prefixes: s-,m-,l-;
 
+//* helper mixin */
 @mixin reverseBoxSizing() {
   width: auto;
   box-sizing: content-box;
   float: none;
 }
 
-@mixin gridClasses($_prefix:'',$breakpoint_min:'',$breakpoint_max:''){
+//* helper mixin */
+@mixin gridClasses($_prefix:'', $gridColumns:12, $padOuter:.5em, $padInner:1em, $breakpoint_min:'', $breakpoint_max:''){
   .#{$_prefix}grid-all {
     margin: 0; clear: none; float: left; 
     -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;  *behavior: url(boxsizing.htc);    
   }
-  @for $i from 1 through $grid-columns {
+  @for $i from 1 through $gridColumns {
     .#{$_prefix}grid-#{$i} {
       @extend .#{$_prefix}grid-all;
-      width:percentage($i/$grid-columns);
+      width:percentage($i/$gridColumns);
     }
     //* generate easy-to-read grid classes */
-    @if $i/$grid-columns == 1/4 {
+    @if $i/$gridColumns == 1/4 {
       .#{$_prefix}grid-quarter {
         @extend .#{$_prefix}grid-#{$i};
       }
     }
-    @if $i/$grid-columns == 1/3 {
+    @if $i/$gridColumns == 1/3 {
       .#{$_prefix}grid-third {
         @extend .#{$_prefix}grid-#{$i};
       }
     }
-    @if $i/$grid-columns == 1/2 {
+    @if $i/$gridColumns == 1/2 {
       .#{$_prefix}grid-half {
         @extend .#{$_prefix}grid-#{$i};
       }
     }
-    @if $i/$grid-columns == 2/3 {
+    @if $i/$gridColumns == 2/3 {
       .#{$_prefix}grid-two-thirds {
         @extend .#{$_prefix}grid-#{$i};
       }
     }
-    @if $i/$grid-columns == 3/4 {
+    @if $i/$gridColumns == 3/4 {
       .#{$_prefix}grid-three-quarters {
         @extend .#{$_prefix}grid-#{$i};
       }
     }
-    @if $i/$grid-columns == 1 {
+    @if $i/$gridColumns == 1 {
       .#{$_prefix}grid-whole {
         @extend .#{$_prefix}grid-#{$i};
       }
@@ -116,39 +114,57 @@ $breakpoint_prefixes: s-,m-,l-;
 }
 
 
-//* generate top-level grid classes */
-@include gridClasses();
+//* generate grid classes for each breakpoint, defaults defined below */
+@mixin gridGenerator(
+         $breakpoints: (0, 480px, 800px), // breakpoints
+         $breakpointType: 'px',           // breakpoint type px or em 
+         $gridColumns: 12,                // number of grid columns 
+         $padOuter: 1em,                  // outer padding 
+         $padInner: .5em,                 // inner padding 
+         $breakpointPrefixes: (s-,m-,l-)  // breakpoint prefixes
+       ) {
 
-//* generate grid classes for each breakpoint */
-@for $i from 1 through length($breakpoint_prefixes) {
-  $prefix: nth($breakpoint_prefixes, $i);
-  $breakpoint_min: nth($breakpoints, $i) + 1;
-  $breakpoint_max: '';
-  @if $i < length($breakpoint_prefixes) {
-    $breakpoint_max: nth($breakpoints, $i+1);
-  }
+  //* generate top-level grid classes, no prefix */
+  @include gridClasses('', $gridColumns, $padInner, $padOuter);
 
-  //* smallest breakpoint */
-  @if $breakpoint_min == 1 {
 
-    @media (max-width: $breakpoint_max) {
-      @include gridClasses($prefix);
+  @for $i from 1 through length($breakpointPrefixes) {
+    $prefix: nth($breakpointPrefixes, $i);
+    $breakpoint_min: nth($breakpoints, $i);
+
+    // Add one to support pixel breakpoints, EMs don't need the extra bump
+    @if $breakpointType == 'px' {
+      $breakpoint_min: nth($breakpoints, $i) + 1;
     }
-        
-  } @else {
 
-    //* middle breakpoints */
-    @if $breakpoint_max != '' {
+    $breakpoint_max: '';
 
-      @media (min-width: $breakpoint_min) and (max-width: $breakpoint_max) {
-        @include gridClasses($prefix);
+    @if $i < length($breakpointPrefixes) {
+      $breakpoint_max: nth($breakpoints, $i+1);
+    }
+
+  //   //* smallest breakpoint */
+    @if $breakpoint_min == 1 {
+
+      @media (max-width: $breakpoint_max) {
+        @include gridClasses($prefix, $gridColumns, $padInner, $padOuter);
       }
-
-    //* largest breakpoint */
+          
     } @else {
 
-      @media (min-width: $breakpoint_min) {
-        @include gridClasses($prefix);
+      //* middle breakpoints */
+      @if $breakpoint_max != '' {
+
+        @media (min-width: $breakpoint_min) and (max-width: $breakpoint_max) {
+          @include gridClasses($prefix, $gridColumns, $padInner, $padOuter);
+        }
+
+      //* largest breakpoint */
+      } @else {
+
+        @media (min-width: $breakpoint_min) {
+          @include gridClasses($prefix, $gridColumns, $padInner, $padOuter);
+        }
       }
     }
   }

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <link rel="shortcut icon" href="./favicon.ico" >
 
   <link href='http://fonts.googleapis.com/css?family=Alfa+Slab+One|PT+Sans:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-  <link href="css/grid.css" rel="stylesheet" />
+  <link href="css/example-grid.css" rel="stylesheet" />
   <link href="css/main.css" rel="stylesheet" />
   <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
@johnpolacek - I've updated the ESRG Sass to decouple the defaults from the top of the file, while morphing ESRG into a mixin called `gridGenerator()`  and added EM breakpoint support.

See example-grid.scss for usage.

``` sass
@include gridGenerator()
```

Example using EMs

``` sass
@include gridGenerator((0,35em,55em), 'em')
```

Example to override all the defaults

``` sass
@include gridGenerator(
  (0, 35em, 55em),   // breakpoints
  'em',              // breakpoint type 'px' or 'em'
  18,                // number of grid columns
  1em,               // outer padding
  1.5em,             // inner padding
  (sm-,med-,lg-)     // breakpoint prefixes
)
```

Happy to make changes, but thought I would let you update the demo/documentation page.
